### PR TITLE
Cache implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ When you **edit** or **create** a FAQ, the plugin shows you the **post ID** just
 - **FAQ ID** displayed in the edit screen.  
 - Automatically inserts **JSON-LD (FAQ Schema)** for each FAQ instance, helping Google identify your FAQ content for potential rich results.  
 - If an older version of the plugin had a custom DB table, the plugin checks for leftover records and alerts you in WP Admin.  
+- New Taxonomy (Category) Support. Display all posts within a category and exclude certain post IDs e.g. 
+[KISSFAQS category="test" exclude="827755,827756" hidden="true"]
 
 ---
 


### PR DESCRIPTION
Cache implementation 

Implementation of transient caching for your KISS FAQs plugin.

Cache Property and Configuration:
Added a class property private $transient_expiry = 86400; (24 hours default)
Added a setting in the admin area to customize the cache duration
Implemented proper sanitization for the expiry value


Cache Utility Methods:
get_faqs_transient_key(): Generates unique cache keys based on shortcode attributes
flush_faq_cache(): Clears all plugin-related transients when content changes
check_faq_delete(): Checks if a deleted post is a FAQ and flushes cache if needed


Caching in Shortcodes:
Both render_faq_shortcode() and render_all_faqs_shortcode() now check for cached content first
Cached outputs are stored with the configured expiration time
Even when using cached output, schema data is still properly collected

Schema Output Caching:
The output_kiss_faq_schema() method now also uses transients for the JSON-LD output
This reduces JSON encoding overhead on each page load

Cache Invalidation Hooks:
Added hooks for post and taxonomy changes to automatically clear cache
This ensures fresh content is shown when FAQs are updated

Admin Settings:
Added a "Cache Duration" field to the existing settings page
The field accepts values in seconds (minimum 60 seconds)
Includes helpful guidance about common duration values