### PR TITLE
Fix shortcode crash on array FAQ content

### DIFF
--- a/kiss-faqs.php
+++ b/kiss-faqs.php
@@ -3,7 +3,7 @@
  * Plugin Name: KISS FAQs with Schema
  * Plugin URI:  https://KISSplugins.com
  * Description: Manage and display FAQs (Question = Post Title, Answer = Post Content Editor) with Google's Structured Data. Shortcode: [KISSFAQ post="ID"]. Safari-friendly toggle, displays FAQ ID in editor, and now has a column showing the shortcode/post ID.
- * Version: 1.04.2
+ * Version: 1.04.3
  * Author: KISS Plugins
  * Author URI: https://KISSplugins.com
  * License: GPL2
@@ -45,7 +45,7 @@ $myUpdateChecker->setBranch('main');
 class KISSFAQsWithSchema {
 
     private static $instance = null;
-    public $plugin_version = '1.04';
+    public $plugin_version = '1.04.3';
     public $db_table_name  = 'KISSFAQs'; // Table name (legacy)
     private static $kiss_faq_schema_data = array();
 
@@ -321,6 +321,9 @@ class KISSFAQsWithSchema {
             // Q = post_title, A = post_content
             $question = $faq->post_title;
             $answer   = apply_filters( 'the_content', $faq->post_content );
+            if ( is_array( $answer ) ) {
+                $answer = implode( '', $answer );
+            }
 
             // Determine hidden setting
             $hidden = ( $index === 0 || 'false' === strtolower( $atts['hidden'] ) ) ? false : true;
@@ -428,6 +431,9 @@ class KISSFAQsWithSchema {
         // Q = post_title, A = post_content
         $question = $post->post_title;
         $answer   = apply_filters( 'the_content', $post->post_content );
+        if ( is_array( $answer ) ) {
+            $answer = implode( '', $answer );
+        }
 
         // Determine hidden setting
         $hidden = ( 'false' === strtolower( $atts['hidden'] ) ) ? false : true;


### PR DESCRIPTION
## Summary
- handle FAQ answers that may come back as arrays
- bump plugin version to 1.04.3

## Testing
- `php -l kiss-faqs.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684cadcb3ea0832e9eec390dba553d2f